### PR TITLE
21801: Reset Ubuntu version to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-cache policy gcc-10
 RUN apt-get update && apt-get install -y cmake ninja-build
 RUN cmake --version
 RUN ninja --version
+RUN ldd --version
 
 # Locale update:
 RUN locale-gen es_ES.utf8 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \


### PR DESCRIPTION
For the meantime, we intend to keep the minimum GLIBC version at 2.31, which is the default version installed by Ubuntu 20.04 and newer Raspberry Pi OS versions.