### PR TITLE
22208: Add Amalgam Build Container linux-228

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -10,6 +10,10 @@ on:
           required: false
           default: ${{ github.repository }}
           type: string
+      docker_file:
+            required: false
+            default: Dockerfile
+            type: string
 
 defaults:
   run:
@@ -39,6 +43,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: ${{ inputs.docker_file }}
           push: false
           tags: |
             ${{ env.REGISTRY }}/${{ inputs.image_name }}:${{ inputs.version }}

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -6,6 +6,10 @@ on:
       version:
         required: true
         type: string
+      image_name:
+          required: false
+          default: ${{ github.repository }}
+          type: string
 
 defaults:
   run:
@@ -13,7 +17,6 @@ defaults:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
 
@@ -29,7 +32,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ inputs.image_name }}
 
 
       - name: Build Docker image
@@ -38,5 +41,6 @@ jobs:
           context: .
           push: false
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+            ${{ env.REGISTRY }}/${{ inputs.image_name }}:${{ inputs.version }}
+            ${{ env.REGISTRY }}/${{ inputs.image_name }}:dev
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -46,6 +46,5 @@ jobs:
           file: ${{ inputs.docker_file }}
           push: false
           tags: |
-            ${{ env.REGISTRY }}/${{ inputs.image_name }}:${{ inputs.version }}
             ${{ env.REGISTRY }}/${{ inputs.image_name }}:dev
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/create-branch-build.yml
+++ b/.github/workflows/create-branch-build.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           version: ${{ needs.set-branch-version.outputs.version }}
           image_name: ${{ github.repository }}-228
+          docker_file: "linux-228/Dockerfile"
 
   # This job is here to have only one final step to add for "Status Checks"
   # in GitHub, instead of adding every leaf test from 'build-test-package'

--- a/.github/workflows/create-branch-build.yml
+++ b/.github/workflows/create-branch-build.yml
@@ -49,6 +49,14 @@ jobs:
     with:
       version: ${{ needs.set-branch-version.outputs.version }}
 
+  build-test-package-228:
+        needs: ['set-branch-version']
+        uses: "./.github/workflows/build-test-package.yml"
+        secrets: inherit
+        with:
+          version: ${{ needs.set-branch-version.outputs.version }}
+          image_name: ${{ github.repository }}-228
+
   # This job is here to have only one final step to add for "Status Checks"
   # in GitHub, instead of adding every leaf test from 'build-test-package'
   final-check:

--- a/.github/workflows/create-pr-build.yml
+++ b/.github/workflows/create-pr-build.yml
@@ -52,6 +52,14 @@ jobs:
     with:
       version: ${{ needs.set-pr-version.outputs.version }}
 
+  build-test-package-228:
+    needs: ['set-pr-version']
+    uses: "./.github/workflows/build-test-package.yml"
+    secrets: inherit
+    with:
+      version: ${{ needs.set-pr-version.outputs.version }}
+      image_name: ${{ github.repository }}-228
+
   # This job is here to have only one final step to add for "Status Checks"
   # in GitHub, instead of adding every leaf test from 'build-test-package'
   final-check:

--- a/.github/workflows/create-pr-build.yml
+++ b/.github/workflows/create-pr-build.yml
@@ -59,6 +59,7 @@ jobs:
     with:
       version: ${{ needs.set-pr-version.outputs.version }}
       image_name: ${{ github.repository }}-228
+      docker_file: "linux-228/Dockerfile"
 
   # This job is here to have only one final step to add for "Status Checks"
   # in GitHub, instead of adding every leaf test from 'build-test-package'

--- a/.github/workflows/create-release-build.yml
+++ b/.github/workflows/create-release-build.yml
@@ -122,3 +122,4 @@ jobs:
     with:
       version: ${{ needs.construct-release-tag.outputs.release-tag }}
       image_name: ${{ github.repository }}-228
+      docker_file: "linux-228/Dockerfile"

--- a/.github/workflows/create-release-build.yml
+++ b/.github/workflows/create-release-build.yml
@@ -114,3 +114,11 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.construct-release-tag.outputs.release-tag }}
+
+  release-228:
+    needs: ['construct-release-tag']
+    uses: "./.github/workflows/release.yml"
+    secrets: inherit
+    with:
+      version: ${{ needs.construct-release-tag.outputs.release-tag }}
+      image_name: ${{ github.repository }}-228

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       version:
         required: true
         type: string
+      image_name:
+          required: false
+          default: ${{ github.repository }}
+          type: string
 
 defaults:
   run:
@@ -13,7 +17,6 @@ defaults:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
 
@@ -29,7 +32,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ inputs.image_name }}
 
       - name: Login to container registry
         uses: docker/login-action@v2
@@ -43,8 +46,8 @@ jobs:
         with:
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ inputs.image_name }}:${{ inputs.version }}
+            ${{ env.REGISTRY }}/${{ inputs.image_name }}:latest
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
           required: false
           default: ${{ github.repository }}
           type: string
+      docker_file:
+            required: false
+            default: Dockerfile
+            type: string
 
 defaults:
   run:
@@ -44,6 +48,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
+          file: ${{ inputs.docker_file }}
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ inputs.image_name }}:${{ inputs.version }}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@ Linux container for building the [Amalgam](https://github.com/howsoai/amalgam) l
 
 ## Building
 
+To build the default Amalgam Linux Build Container
 ```bash
 docker build -t amalgam-build-container-linux .
+```
+
+To build the Oracle Linux 8.x Container to support GLIBC 2.28
+```bash
+docker build -f linux-228/Dockerfile -t amalgam-build-container-linux-228 .
 ```
 
 ## License

--- a/linux-228/Dockerfile
+++ b/linux-228/Dockerfile
@@ -1,0 +1,47 @@
+# The purpose of this dockerfile is to generate a build container
+# for Amalgam builds using GLIBC_2_28 so we can support Oracle
+# Linx 8.x for an important customer.
+FROM oraclelinux:8
+
+# Install necessary tools
+RUN dnf update -y \
+    && dnf install -y \
+       sudo gcc gcc-c++ make git wget python3 \
+       python3-pip python3-setuptools python3-wheel tzdata clang \
+       glibc glibc-locale-source glibc-langpack-en glibc-langpack-es binutils \
+       epel-release \
+    && dnf install -y \
+       gcc-toolset-10-gcc gcc-toolset-10-gcc-c++ \
+    && dnf clean all
+
+# Set Timezone to be America/New_York aka Eastern Timezone.
+RUN mkdir -p /zoneinfo && cp -r /usr/share/zoneinfo/* /zoneinfo
+ENV TZ=America/New_York
+RUN mkdir -p /etc \
+   && sudo ln -snf /usr/share/zoneinfo/America/New_York /etc/localtime \
+   && echo $TZ > /etc/timezone
+
+# Set environment for GCC 10
+ENV PATH=/opt/rh/gcc-toolset-10/root/usr/bin:$PATH
+
+# Install cmake and ninja-build
+RUN dnf install -y dnf-plugins-core \
+    && dnf --enablerepo=ol8_codeready_builder install cmake ninja-build \
+    && dnf clean all
+
+# Print version info
+RUN cmake --version \
+    && ninja --version \
+    && ldd --version
+
+# Locale setup for Spanish (no locales package, use langpack instead)
+ENV LANG=es_ES.UTF-8
+RUN localedef -i es_ES -f UTF-8 es_ES.UTF-8
+
+# Default GCC setup
+RUN update-alternatives --install /usr/bin/gcc gcc /opt/rh/gcc-toolset-10/root/usr/bin/gcc 100 \
+    --slave /usr/bin/g++ g++ /opt/rh/gcc-toolset-10/root/usr/bin/g++ \
+    --slave /usr/bin/gcov gcov /opt/rh/gcc-toolset-10/root/usr/bin/gcov \
+    && update-alternatives --set gcc /opt/rh/gcc-toolset-10/root/usr/bin/gcc
+
+RUN gcc --version && ldd --version


### PR DESCRIPTION
Adds the Amalgam Linux 228 Build Container to this project.
This allows us to support amalgam builds with GLIBC2_28.
This is accomplished by using Oracle Linux 8.x official container which has GLIBC_2_28.