### PR TITLE
25833: Updates container image to support Amalgam GCC/C++ build upgrade

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -14,6 +14,10 @@ on:
             required: false
             default: Dockerfile
             type: string
+      platforms:
+            required: false
+            default: "linux/amd64,linux/arm64"
+            type: string
 
 defaults:
   run:
@@ -39,11 +43,20 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ inputs.image_name }}
 
 
+      # Needed to build the linux/arm64 layers of the multi-arch manifest from an amd64
+      # runner. This is image build time only -- Amalgam itself is built natively.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ${{ inputs.docker_file }}
+          platforms: ${{ inputs.platforms }}
           push: false
           tags: |
             ${{ env.REGISTRY }}/${{ inputs.image_name }}:dev

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ inputs.image_name }}
 
@@ -52,7 +52,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ inputs.docker_file }}

--- a/.github/workflows/create-branch-build.yml
+++ b/.github/workflows/create-branch-build.yml
@@ -62,8 +62,10 @@ jobs:
 
   # This job is here to have only one final step to add for "Status Checks"
   # in GitHub, instead of adding every leaf test from 'build-test-package'
+  # Note: both image lanes must be listed -- 'needs.*' only spans the jobs named here,
+  # so omitting the 228 lane would let a glibc 2.28 build failure pass the status check.
   final-check:
-    needs: ['build-test-package']
+    needs: ['build-test-package', 'build-test-package-228']
     if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create-branch-build.yml
+++ b/.github/workflows/create-branch-build.yml
@@ -57,6 +57,8 @@ jobs:
           version: ${{ needs.set-branch-version.outputs.version }}
           image_name: ${{ github.repository }}-228
           docker_file: "linux-228/Dockerfile"
+          # GLIBC 2.28 support is only needed for amd64
+          platforms: "linux/amd64"
 
   # This job is here to have only one final step to add for "Status Checks"
   # in GitHub, instead of adding every leaf test from 'build-test-package'

--- a/.github/workflows/create-branch-build.yml
+++ b/.github/workflows/create-branch-build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get previous git tag
         id: previous-tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
+        uses: WyriHaximus/github-action-get-previous-tag@v2
         with:
           fallback: 0.0.0
 

--- a/.github/workflows/create-pr-build.yml
+++ b/.github/workflows/create-pr-build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get previous git tag
         id: previous-tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
+        uses: WyriHaximus/github-action-get-previous-tag@v2
         with:
           fallback: 0.0.0
 

--- a/.github/workflows/create-pr-build.yml
+++ b/.github/workflows/create-pr-build.yml
@@ -65,8 +65,10 @@ jobs:
 
   # This job is here to have only one final step to add for "Status Checks"
   # in GitHub, instead of adding every leaf test from 'build-test-package'
+  # Note: both image lanes must be listed -- 'needs.*' only spans the jobs named here,
+  # so omitting the 228 lane would let a glibc 2.28 build failure pass the status check.
   final-check:
-    needs: ['build-test-package']
+    needs: ['build-test-package', 'build-test-package-228']
     if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create-pr-build.yml
+++ b/.github/workflows/create-pr-build.yml
@@ -60,6 +60,8 @@ jobs:
       version: ${{ needs.set-pr-version.outputs.version }}
       image_name: ${{ github.repository }}-228
       docker_file: "linux-228/Dockerfile"
+      # GLIBC 2.28 support is only needed for amd64
+      platforms: "linux/amd64"
 
   # This job is here to have only one final step to add for "Status Checks"
   # in GitHub, instead of adding every leaf test from 'build-test-package'

--- a/.github/workflows/create-release-build.yml
+++ b/.github/workflows/create-release-build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get previous git tag
         id: previous-tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
+        uses: WyriHaximus/github-action-get-previous-tag@v2
         with:
           fallback: 0.0.0
 

--- a/.github/workflows/create-release-build.yml
+++ b/.github/workflows/create-release-build.yml
@@ -123,4 +123,6 @@ jobs:
       version: ${{ needs.construct-release-tag.outputs.release-tag }}
       image_name: ${{ github.repository }}-228
       docker_file: "linux-228/Dockerfile"
+      # GLIBC 2.28 support is only needed for amd64
+      platforms: "linux/amd64"
       create_release: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ on:
         required: false
         default: true
         type: boolean
+      platforms:
+        required: false
+        default: "linux/amd64,linux/arm64"
+        type: string
 
 defaults:
   run:
@@ -49,10 +53,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      # Needed to build the linux/arm64 layers of the multi-arch manifest from an amd64
+      # runner. This is image build time only -- Amalgam itself is built natively.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           file: ${{ inputs.docker_file }}
+          platforms: ${{ inputs.platforms }}
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ inputs.image_name }}:${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ inputs.image_name }}
 
@@ -62,7 +62,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           file: ${{ inputs.docker_file }}
           platforms: ${{ inputs.platforms }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,25 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
+# Note: this image is published as a multi-arch manifest (linux/amd64 + linux/arm64) so
+# that each Amalgam arch builds natively on a runner of the same arch. No cross-compilers
+# and no qemu-user: arm64 is no longer cross-compiled or emulated.
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
 && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-   apt-transport-https software-properties-common \
-   sudo build-essential gcc-10 g++-10 git wget python3 \
+   apt-transport-https software-properties-common ca-certificates gpg \
+   sudo build-essential gcc-14 g++-14 git wget python3 \
    pipx python-is-python3 tzdata locales clang \
-   gcc-10-aarch64-linux-gnu g++-10-aarch64-linux-gnu \
-   binutils-aarch64-linux-gnu qemu-user \
+   cmake ninja-build \
 && apt-get autoremove -y \
 && apt-get purge -y --auto-remove \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/
 
-RUN apt-cache policy gcc-10
-
-# Secondary installs
-RUN apt-get install -y ca-certificates gpg
-RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-RUN apt-get update
-RUN apt list -a cmake
-RUN apt-get install -y cmake ninja-build
+RUN apt-cache policy gcc-14
 
 # Print version info
+# Note: Ubuntu 24.04 ships CMake 3.28, which satisfies Amalgam's 3.26 minimum, so the
+# Kitware apt repo that the previous 20.04 based image needed is no longer required.
 RUN cmake --version
 RUN ninja --version
 RUN ldd --version
@@ -33,22 +29,30 @@ RUN locale-gen es_ES.utf8 \
 && update-locale
 
 # Default GCC:
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10 \
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 --slave /usr/bin/g++ g++ /usr/bin/g++-14 --slave /usr/bin/gcov gcov /usr/bin/gcov-14 \
 && update-alternatives --config gcc
 
 RUN gcc --version
 
 # WASM compiler:
-RUN mkdir -p /wasm \
-&& git clone https://github.com/emscripten-core/emsdk.git /wasm/emsdk \
-&& cd /wasm/emsdk \
-&& ./emsdk install 3.1.67 \
-&& ./emsdk activate 3.1.67
+# Note: wasm64 is only built on amd64, so emsdk is skipped on arm64 to avoid a slow
+# emulated install when this image is built as a multi-arch manifest. The arch is read
+# from dpkg rather than the TARGETARCH build arg so this behaves the same whether or not
+# the image is built through buildx.
+RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+    mkdir -p /wasm \
+    && git clone https://github.com/emscripten-core/emsdk.git /wasm/emsdk \
+    && cd /wasm/emsdk \
+    && ./emsdk install 3.1.67 \
+    && ./emsdk activate 3.1.67; \
+    fi
 ENV PATH="/wasm/emsdk/upstream/emscripten:${PATH}"
 
 # tzdata for WASM:
-RUN cd /wasm \
-&& mkdir tzdata && mkdir etc \
-&& wget https://data.iana.org/time-zones/releases/tzdata2024b.tar.gz \
-&& tar -xzf tzdata*.tar.gz -C tzdata \
-&& echo "Etc/UTC" > ./etc/timezone
+RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+    cd /wasm \
+    && mkdir tzdata && mkdir etc \
+    && wget https://data.iana.org/time-zones/releases/tzdata2024b.tar.gz \
+    && tar -xzf tzdata*.tar.gz -C tzdata \
+    && echo "Etc/UTC" > ./etc/timezone; \
+    fi

--- a/README.md
+++ b/README.md
@@ -4,12 +4,22 @@ Linux container for building the [Amalgam](https://github.com/howsoai/amalgam) l
 
 ## Building
 
-To build the default Amalgam Linux Build Container
+To build the default Amalgam Linux Build Container for the host architecture
 ```bash
 docker build -t amalgam-build-container-linux .
 ```
 
-To build the Oracle Linux 8.x Container to support GLIBC 2.28
+The released image is a multi-arch manifest (`linux/amd64` and `linux/arm64`) so that each
+Amalgam architecture is built natively on a runner of the same architecture. To reproduce
+that locally:
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t amalgam-build-container-linux .
+```
+
+Note: the Emscripten SDK is only installed in the `amd64` image, since `wasm64` is only
+ever built on `amd64`.
+
+To build the Oracle Linux 8.x Container to support GLIBC 2.28 (`amd64` only)
 ```bash
 docker build -f linux-228/Dockerfile -t amalgam-build-container-linux-228 .
 ```

--- a/linux-228/Dockerfile
+++ b/linux-228/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf update -y \
        glibc glibc-locale-source glibc-langpack-en glibc-langpack-es binutils \
        epel-release \
     && dnf install -y \
-       gcc-toolset-10-gcc gcc-toolset-10-gcc-c++ \
+       gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ \
     && dnf clean all
 
 # Set Timezone to be America/New_York aka Eastern Timezone.
@@ -21,8 +21,8 @@ RUN mkdir -p /etc \
    && sudo ln -snf /usr/share/zoneinfo/America/New_York /etc/localtime \
    && echo $TZ > /etc/timezone
 
-# Set environment for GCC 10
-ENV PATH=/opt/rh/gcc-toolset-10/root/usr/bin:$PATH
+# Set environment for GCC 14
+ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:$PATH
 
 # Install cmake and ninja-build
 RUN dnf install -y dnf-plugins-core \
@@ -39,9 +39,9 @@ ENV LANG=es_ES.UTF-8
 RUN localedef -i es_ES -f UTF-8 es_ES.UTF-8
 
 # Default GCC setup
-RUN update-alternatives --install /usr/bin/gcc gcc /opt/rh/gcc-toolset-10/root/usr/bin/gcc 100 \
-    --slave /usr/bin/g++ g++ /opt/rh/gcc-toolset-10/root/usr/bin/g++ \
-    --slave /usr/bin/gcov gcov /opt/rh/gcc-toolset-10/root/usr/bin/gcov \
-    && update-alternatives --set gcc /opt/rh/gcc-toolset-10/root/usr/bin/gcc
+RUN update-alternatives --install /usr/bin/gcc gcc /opt/rh/gcc-toolset-14/root/usr/bin/gcc 100 \
+    --slave /usr/bin/g++ g++ /opt/rh/gcc-toolset-14/root/usr/bin/g++ \
+    --slave /usr/bin/gcov gcov /opt/rh/gcc-toolset-14/root/usr/bin/gcov \
+    && update-alternatives --set gcc /opt/rh/gcc-toolset-14/root/usr/bin/gcc
 
 RUN gcc --version && ldd --version

--- a/linux-228/Dockerfile
+++ b/linux-228/Dockerfile
@@ -15,10 +15,12 @@ RUN dnf update -y \
     && dnf clean all
 
 # Set Timezone to be America/New_York aka Eastern Timezone.
+# Note: no sudo here -- every RUN already executes as root, and sudo's PAM account
+# lookup fails under buildx's docker-container driver.
 RUN mkdir -p /zoneinfo && cp -r /usr/share/zoneinfo/* /zoneinfo
 ENV TZ=America/New_York
 RUN mkdir -p /etc \
-   && sudo ln -snf /usr/share/zoneinfo/America/New_York /etc/localtime \
+   && ln -snf /usr/share/zoneinfo/America/New_York /etc/localtime \
    && echo $TZ > /etc/timezone
 
 # Set environment for GCC 14


### PR DESCRIPTION
Prerequisite work for Amalgam builds to now use GCC14 & C++20 while still maintaining a glibc 2.28 variant.